### PR TITLE
Angular 1.6.X and 1.7.X compatibility

### DIFF
--- a/demo/demo.js
+++ b/demo/demo.js
@@ -6,6 +6,9 @@
             // HTML 5 mode (works both, try it out)
             $locationProvider.html5Mode(false);
 
+            // Override angularjs 1.6 default hash prefix from '!' to '' as it was in 1.5
+            $locationProvider.hashPrefix('');
+
             // URL prefixes
             $dataRouterProvider.apiPrefix('api/');
 

--- a/src/directives/emptyHref.js
+++ b/src/directives/emptyHref.js
@@ -28,9 +28,10 @@ module.directive('emptyHref', function emptyHrefFactory($log) {
         priority: 0,
         link: function emptyHrefLink(scope, element, attrs) {
             var observer;
+            var emptyHrefAttr = attrs['emptyHref'] ? attrs['emptyHref'].toLowerCase() : attrs['emptyHref'];
 
             // Modes
-            switch (angular.lowercase(attrs['emptyHref'])) {
+            switch (emptyHrefAttr) {
                 case 'hide':
                     observer = function hrefHideObserver(href) {
                         element.toggleClass('ng-hide', !href && href !== '');


### PR DESCRIPTION
- Substituted angular.lowercase deprecated api that is removed since angular 1.7.X
- Hash prefix overriden in demo application (from '!' to empty string) for consistent behaviour between angular versions 1.5.X and 1.6.X.